### PR TITLE
Update table_cell.rb - changed mysql alias groups for upwards compatibility

### DIFF
--- a/app/cells/members/table_cell.rb
+++ b/app/cells/members/table_cell.rb
@@ -55,8 +55,8 @@ module Members
           "
             LEFT JOIN group_users AS group_users
               ON group_users.user_id = members.user_id
-            LEFT JOIN (SELECT id, lastname AS group_name FROM users) AS groups
-              ON groups.id = group_users.group_id
+            LEFT JOIN (SELECT id, lastname AS group_name FROM users) AS groupalias
+              ON groupalias.id = group_users.group_id
           "
         )
     end


### PR DESCRIPTION
Alias name "groups" results in an error while using mysql 8.0.13:
(1064): Syntax error near 'groups ON groups.id = group_users.group_id WHERE `members`.`id` IN (SELECT `mem' at line 7